### PR TITLE
Fixes for dataset-related queries

### DIFF
--- a/hubmapy/queries/anatomical_structures_in_tissue_block.rq
+++ b/hubmapy/queries/anatomical_structures_in_tissue_block.rq
@@ -6,11 +6,14 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX dc: <http://purl.org/dc/terms/>
 PREFIX hgnc: <http://identifiers.org/hgnc/>
 
-SELECT ?anatomical_structure ?anatomical_structure_label ?donor ?donor_sex WHERE {
-    ?tissue_block rdf:type ccf:tissue_block ;
+SELECT DISTINCT ?anatomical_structure ?anatomical_structure_label ?donor ?donor_sex
+FROM <https://purl.humanatlas.io/graph/ccf>
+FROM <https://purl.humanatlas.io/ds-graph/hubmap>
+WHERE {
+    ?tissue_block rdf:type ccf:Sample ;
         ccf:has_registration_location [ ccf:collides_with ?anatomical_structure ] ;
         ccf:comes_from ?donor .
     OPTIONAL { ?anatomical_structure rdfs:label ?anatomical_structure_label }
-    OPTIONAL { ?donor ccf:has_biological_sex [ rdfs:label ?donor_sex ] }
+    OPTIONAL { ?donor ccf:sex ?donor_sex }
 }
 ORDER BY ?anatomical_structure_label

--- a/hubmapy/queries/tissue_block_count_for_all_anatomical_structures.rq
+++ b/hubmapy/queries/tissue_block_count_for_all_anatomical_structures.rq
@@ -6,8 +6,11 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX dc: <http://purl.org/dc/terms/>
 PREFIX hgnc: <http://identifiers.org/hgnc/>
 
-SELECT (count(?tissue_block) as ?tissue_block_count) ?anatomical_structure ?anatomical_structure_label WHERE {
-    ?tissue_block rdf:type ccf:tissue_block ;
+SELECT (count(?tissue_block) as ?tissue_block_count) ?anatomical_structure ?anatomical_structure_label
+FROM <https://purl.humanatlas.io/graph/ccf>
+FROM <https://purl.humanatlas.io/ds-graph/hubmap>
+WHERE {
+    ?tissue_block rdf:type ccf:Sample ;
         ccf:has_registration_location [ ccf:collides_with ?anatomical_structure ] .
     BIND(IRI(?anatomical_structure) as ?anatomical_structure_iri) .
     ?anatomical_structure_iri rdfs:label ?anatomical_structure_label

--- a/hubmapy/queries/tissue_blocks_in_anatomical_structure.rq
+++ b/hubmapy/queries/tissue_blocks_in_anatomical_structure.rq
@@ -6,10 +6,13 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX dc: <http://purl.org/dc/terms/>
 PREFIX hgnc: <http://identifiers.org/hgnc/>
 
-SELECT ?tissue_block ?donor ?donor_sex WHERE {
-    ?tissue_block rdf:type ccf:tissue_block ;
-        ccf:has_registration_location [ ccf:collides_with ?anatomical_structure ] ;
+SELECT DISTINCT ?tissue_block ?donor ?donor_sex
+FROM <https://purl.humanatlas.io/graph/ccf>
+FROM <https://purl.humanatlas.io/ds-graph/hubmap>
+WHERE {
+    ?tissue_block rdf:type ccf:Sample ;
+    ccf:has_registration_location [ ccf:collides_with ?anatomical_structure ] ;
         ccf:comes_from ?donor .
-    ?donor ccf:has_biological_sex [ rdfs:label ?donor_sex ]
+    ?donor ccf:sex ?donor_sex .
 }
 ORDER BY ?tissue_block


### PR DESCRIPTION
Use a second named graph for hubmap datasets when querying against dataset-related data

Your code will need to be updated to handle a second rdf graph. Happy to go over how you could do that depending on your needs.